### PR TITLE
BUG: prevent the use of __thread on QNX

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -131,7 +131,12 @@
 #endif
 
 #ifdef HAVE___THREAD
-    #define NPY_TLS __thread
+    /* __thread doesn't work on QNX */
+    #ifndef __QNX__
+        #define NPY_TLS __thread
+    #else
+        #define NPY_TLS
+    #endif
 #else
     #ifdef HAVE___DECLSPEC_THREAD_
         #define NPY_TLS __declspec(thread)


### PR DESCRIPTION
If the __thread keyword is used on QNX, then loading numpy fails (see issue #13824).
The use of this keyword will now be prevented if the define __QNX__ is set.

